### PR TITLE
Correct bed for picard qc app

### DIFF
--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -160,10 +160,10 @@
             }
           },
           {
-            "$dnanexus_link": "file-G0Y97F0433GqF68j5fvz9fb6"
+            "$dnanexus_link": "file-G0bFvXQ433GZJq780QgxZxKf"
           },
           {
-            "$dnanexus_link": "file-G0bFvXQ433GZJq780QgxZxKf"
+            "$dnanexus_link": "file-G0Y97F0433GqF68j5fvz9fb6"
           }
         ]
       }
@@ -203,7 +203,7 @@
         },
         "run_CollectTargetedPcrMetrics": true,
         "bedfile": {
-          "$dnanexus_link": "file-FxqKj7041zgFVG0y9kFG7p8Z"
+          "$dnanexus_link": "file-Fzp57Jj41zg5KbV72PVVGkkb"
         },
         "fasta_index": {
           "$dnanexus_link": "file-Fy4j2G04qB6zQK885B5Q8Pqp"


### PR DESCRIPTION
Includes correct GRCh38_probes_myeloid.bed for Picard_qc app

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_uranus_main_workflow/2)
<!-- Reviewable:end -->
