### PR TITLE
v1.1.0 uranus main workflow update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,15 @@ DNAnexus Uranus workflow to support the Haem-Onc myeloid project
 
 -------
 
-## Current Version: 1.0.0
+## Current Version: 1.1.0
 
 ## What apps are used in this workflow?
 
 |  App 	| Version  	|
 |---	|---	|
-|multi_fastqc       |v1.1.0|
-|sentieon_tnseq     |2.1.0|
+|multi_fastqc       |1.1.0|
+|sentieon_bwa_mem   |2.1.0|
+|sentieon_bam_to_vcf|2.1.0|_
 |pindel				|1.0.0|
 |cgppindel          |1.0.0|
 |swiss_army_knife	|4.0.1|

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,6 +1,6 @@
 {
-  "name": "uranus_main_workflow_GRCh38_v1.1.0_dev",
-  "title": "uranus_main_workflow_GRCh38_v1.1.0_dev",
+  "name": "uranus_main_workflow_GRCh38_v1.1.0",
+  "title": "uranus_main_workflow_GRCh38_v1.1.0",
   "stages": [
     {
       "id": "stage-G0q44PQ433GYV97qKk0zkb4J",
@@ -28,6 +28,11 @@
         "genome_fastagz": {
           "$dnanexus_link": "file-Fy4gjFj41zgGjKJ85FYYPX4q"
         },
+        "somatic_algo": "TNhaplotyper2",
+        "run_bqsr": true,
+        "panel_of_normal_vcfgz": {
+          "$dnanexus_link": "file-FxGJf3j41zg0zGX849JGpJ1v"
+        },
         "gatk_resource_bundle": {
           "$dnanexus_link": {
             "project": "project-F3zqGV04fXX5j7566869fjFq",
@@ -39,11 +44,7 @@
             "outputField": "mappings_bam",
             "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
-        },
-        "panel_of_normal_vcfgz": {
-          "$dnanexus_link": "file-FxGJf3j41zg0zGX849JGpJ1v"
-        },
-        "somatic_algo": "TNhaplotyper2"
+        }
       }
     },
     {

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,26 +1,32 @@
 {
-  "name": "uranus_main_workflow_GRCh38_v1.0.0",
-  "title": "uranus_main_workflow_GRCh38_v1.0.0",
+  "name": "uranus_main_workflow_GRCh38_v1.1.0_dev",
+  "title": "uranus_main_workflow_GRCh38_v1.1.0_dev",
   "stages": [
     {
-      "id": "stage-FyPX7qj433GfB76yFQfjZYp4",
+      "id": "stage-G0q44PQ433GYV97qKk0zkb4J",
       "executable": "applet-FvyXygj433GbKPPY0QY8ZKQG",
       "folder": "multi_fastqc_v1.1.0"
     },
     {
-      "id": "stage-Fy4j46j41zgKy4v7628xj2fj",
-      "executable": "app-sentieon-tnseq/2.1.0",
-      "folder": "sentieon_tnseq",
+      "id": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
+      "executable": "app-sentieon-bwa/2.1.0",
+      "folder": "sentieon_bam",
       "input": {
         "genome_fastagz": {
           "$dnanexus_link": "file-Fy4gjFj41zgGjKJ85FYYPX4q"
         },
-        "somatic_algo": "TNhaplotyper2",
         "genomebwaindex_targz": {
           "$dnanexus_link": "file-Fy4p4K040Pgy8XjKG41ZqzxZ"
-        },
-        "panel_of_normal_vcfgz": {
-          "$dnanexus_link": "file-FxGJf3j41zg0zGX849JGpJ1v"
+        }
+      }
+    },
+    {
+      "id": "stage-G0qpY1Q433GpzBp958KJYfBK",
+      "executable": "app-sentieon-tnbam/2.1.0",
+      "folder": "sentieon_vcfs",
+      "input": {
+        "genome_fastagz": {
+          "$dnanexus_link": "file-Fy4gjFj41zgGjKJ85FYYPX4q"
         },
         "gatk_resource_bundle": {
           "$dnanexus_link": {
@@ -28,13 +34,38 @@
             "id": "file-F3zvKp84fXX8qJx43zZXP395"
           }
         },
-        "output_md5sum": true,
-        "output_metrics": true
-      },
-      "systemRequirements": {
-        "*": {
-          "instanceType": "mem1_ssd1_x8"
-        }
+        "mappings_bam": {
+          "$dnanexus_link": {
+            "outputField": "mappings_bam",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
+          }
+        },
+        "panel_of_normal_vcfgz": {
+          "$dnanexus_link": "file-FxGJf3j41zg0zGX849JGpJ1v"
+        },
+        "somatic_algo": "TNhaplotyper2"
+      }
+    },
+    {
+      "id": "stage-G0gx0zQ433GkVKk6KBQjJ2f3",
+      "executable": "app-swiss-army-knife/4.0.1",
+      "folder": "bsvi_vcfs",
+      "input": {
+        "cmd": "sh remove_germline_risk_v*.sh",
+        "in": [
+          {
+            "$dnanexus_link": {
+              "outputField": "variants_vcf",
+              "stage": "stage-G0qpY1Q433GpzBp958KJYfBK"
+            }
+          },
+          {
+            "$dnanexus_link": {
+              "project": "container-G0gx4604yP73FP7y9kbp7z8z",
+              "id": "file-G0gvzfQ433GVp9XBKqV771KG"
+            }
+          }
+        ]
       }
     },
     {
@@ -42,27 +73,27 @@
       "executable": "applet-FyFKBV841zg66G9447B0xKVQ",
       "folder": "pindel_v1.0.0",
       "input": {
-        "export_vcf_advanced_options": "-R hg38 -d 25009 --min_size 1 --min_coverage 10 --min_supporting_reads 5",
+        "mappings_files": [
+          {
+            "$dnanexus_link": {
+              "outputField": "mappings_bam",
+              "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
+            }
+          }
+        ],
         "vcf_gatk_compatible": true,
         "reference_fasta": {
           "$dnanexus_link": "file-Fy4gjFj41zgGjKJ85FYYPX4q"
         },
-        "mappings_files": [
-          {
-            "$dnanexus_link": {
-              "outputField": "tumor_mappings_bam",
-              "stage": "stage-Fy4j46j41zgKy4v7628xj2fj"
-            }
-          }
-        ],
+        "export_vcf_advanced_options": "-R hg38 -d 25009 --min_size 1 --min_coverage 10 --min_supporting_reads 5",
         "fasta_index": {
           "$dnanexus_link": "file-G00jqQj4J7Byv963KkZ40kXv"
         },
         "bam_index_files": [
           {
             "$dnanexus_link": {
-              "outputField": "tumor_mappings_bam_bai",
-              "stage": "stage-Fy4j46j41zgKy4v7628xj2fj"
+              "outputField": "mappings_bam_bai",
+              "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
             }
           }
         ],
@@ -83,10 +114,10 @@
             }
           },
           {
-            "$dnanexus_link": "file-G0Y976Q433GqKVJZJF2QJbB0"
+            "$dnanexus_link": "file-G0bFvXQ433GZJq780QgxZxKf"
           },
           {
-            "$dnanexus_link": "file-G0bFvXQ433GZJq780QgxZxKf"
+            "$dnanexus_link": "file-G0kpq7Q433Gj2XQ89FXYpBzq"
           }
         ]
       }
@@ -101,8 +132,8 @@
         },
         "tumour": {
           "$dnanexus_link": {
-            "outputField": "tumor_mappings_bam",
-            "stage": "stage-Fy4j46j41zgKy4v7628xj2fj"
+            "outputField": "mappings_bam",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
         },
         "reference": {
@@ -116,8 +147,8 @@
         },
         "tumour_index": {
           "$dnanexus_link": {
-            "outputField": "tumor_mappings_bam_bai",
-            "stage": "stage-Fy4j46j41zgKy4v7628xj2fj"
+            "outputField": "mappings_bam_bai",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
         },
         "genes": {
@@ -178,14 +209,14 @@
         },
         "input_bam_index": {
           "$dnanexus_link": {
-            "outputField": "tumor_mappings_bam_bai",
-            "stage": "stage-Fy4j46j41zgKy4v7628xj2fj"
+            "outputField": "mappings_bam_bai",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
         },
         "input_bam": {
           "$dnanexus_link": {
-            "outputField": "tumor_mappings_bam",
-            "stage": "stage-Fy4j46j41zgKy4v7628xj2fj"
+            "outputField": "mappings_bam",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
         }
       }
@@ -197,8 +228,8 @@
       "input": {
         "sorted_bam": {
           "$dnanexus_link": {
-            "outputField": "tumor_mappings_bam",
-            "stage": "stage-Fy4j46j41zgKy4v7628xj2fj"
+            "outputField": "mappings_bam",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
         },
         "run_CollectTargetedPcrMetrics": true,
@@ -217,14 +248,14 @@
       "input": {
         "input_bam_index": {
           "$dnanexus_link": {
-            "outputField": "tumor_mappings_bam_bai",
-            "stage": "stage-Fy4j46j41zgKy4v7628xj2fj"
+            "outputField": "mappings_bam_bai",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
         },
         "input_bam": {
           "$dnanexus_link": {
-            "outputField": "tumor_mappings_bam",
-            "stage": "stage-Fy4j46j41zgKy4v7628xj2fj"
+            "outputField": "mappings_bam",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
         }
       }
@@ -236,14 +267,14 @@
       "input": {
         "index": {
           "$dnanexus_link": {
-            "outputField": "tumor_mappings_bam_bai",
-            "stage": "stage-Fy4j46j41zgKy4v7628xj2fj"
+            "outputField": "mappings_bam_bai",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
         },
         "bam": {
           "$dnanexus_link": {
-            "outputField": "tumor_mappings_bam",
-            "stage": "stage-Fy4j46j41zgKy4v7628xj2fj"
+            "outputField": "mappings_bam",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
         },
         "bed": {


### PR DESCRIPTION
V1.1.0 
* Replaces sentieon tnseq v2.1.0 with sentieon bwa-mem v2.1.0 and sentieon somatic bam to vcf v2.1.0
* Includes an additional swiss army knife app that run the remove_germline_risk_v1.0.0.sh script to remove the germline_risk annotation on vcfs produced by sentieon. 
* Updated version of the pindel filtering script, pindel_filtering_v1.1.0.sh to filter the pindel vcfs using a single command and replacing the bcftools concat command that produced errors with overlapping regions.
* set "Calculate output md5sum"  to false to prevent sentieon from randomly stalling 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_uranus_main_workflow/4)
<!-- Reviewable:end -->