### PR TITLE
Updated v1.3.0 main uranus workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ DNAnexus Uranus workflow to support the Haem-Onc myeloid project
 
 -------
 
-## Current Version: 1.2.0
+## Current Version: 1.3.0
 
 ## What apps are used in this workflow?
 
@@ -12,12 +12,11 @@ DNAnexus Uranus workflow to support the Haem-Onc myeloid project
 |multi_fastqc       |1.1.0|
 |sentieon_bwa_mem   |2.1.0|
 |sentieon_bam_to_vcf|2.1.0|_
-|pindel				|1.0.0|
+|eggd_vcf_handler_for_uranus|1.4.12|
 |cgppindel          |1.0.0|
-|swiss_army_knife	|4.0.1|
-|swiss_army_knife	|4.1.1|
+|swiss_army_knife	|4.3.0|
 |verifybamid        |2.1.0|
 |picardqc           |1.0.0|
 |samtools_flagstat  |1.0.0|
 |mosdepth           |1.0.1|
-|athena             |1.1.1|
+|athena             |1.1.2|

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,6 +1,6 @@
 {
-  "name": "uranus_main_workflow_GRCh38_v1.2.0",
-  "title": "uranus_main_workflow_GRCh38_v1.2.0",
+  "name": "uranus_main_workflow_GRCh38_v1.3.0",
+  "title": "uranus_main_workflow_GRCh38_v1.3.0",
   "stages": [
     {
       "id": "stage-G0q44PQ433GYV97qKk0zkb4J",
@@ -25,9 +25,13 @@
       "executable": "app-sentieon-tnbam/2.1.0",
       "folder": "sentieon_vcfs",
       "input": {
-        "somatic_algo": "TNhaplotyper2",
         "genome_fastagz": {
           "$dnanexus_link": "file-Fy4gjFj41zgGjKJ85FYYPX4q"
+        },
+        "somatic_algo": "TNhaplotyper2",
+        "run_bqsr": true,
+        "panel_of_normal_vcfgz": {
+          "$dnanexus_link": "file-FxGJf3j41zg0zGX849JGpJ1v"
         },
         "gatk_resource_bundle": {
           "$dnanexus_link": {
@@ -35,117 +39,34 @@
             "id": "file-F3zvKp84fXX8qJx43zZXP395"
           }
         },
-        "panel_of_normal_vcfgz": {
-          "$dnanexus_link": "file-FxGJf3j41zg0zGX849JGpJ1v"
-        },
         "mappings_bam": {
           "$dnanexus_link": {
-            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
-            "outputField": "mappings_bam"
+            "outputField": "mappings_bam",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
-        },
-        "run_bqsr": true
+        }
       }
     },
     {
-      "id": "stage-G0gx0zQ433GkVKk6KBQjJ2f3",
-      "executable": "app-swiss-army-knife/4.0.1",
-      "folder": "germline_risk_remove",
+      "id": "stage-G21GYKj4q5J37F0B5ky018QG",
+      "executable": "app-eggd_vcf_handler_for_uranus/1.4.12",
+      "folder": "eggd_vcf_handler_for_uranus_v1.4.12",
       "input": {
-        "in": [
-          {
-            "$dnanexus_link": {
-              "stage": "stage-G0qpY1Q433GpzBp958KJYfBK",
-              "outputField": "variants_vcf"
-            }
-          },
-          {
-            "$dnanexus_link": {
-              "project": "container-G0kxV484p9P1bf2qgV7Z7J5q",
-              "id": "file-G0gvzfQ433GVp9XBKqV771KG"
-            }
-          }
-        ],
-        "cmd": "sh remove_germline_risk_v*.sh"
-      }
-    },
-    {
-      "id": "stage-G18JF28433GkzzVJ3Gk4199k",
-      "executable": "app-swiss-army-knife/4.1.1",
-      "folder": "bsvi_vcfs",
-      "input": {
-        "in": [
-          {
-            "$dnanexus_link": {
-              "stage": "stage-G0gx0zQ433GkVKk6KBQjJ2f3",
-              "outputField": "out"
-            }
-          },
-          {
-            "$dnanexus_link": "file-G18J8b0433Gg33VJ8x9qPbfk"
-          },
-          {
-            "$dnanexus_link": "file-G18J8pj433GzpFpF9F9q0Y64"
-          },
-          {
-            "$dnanexus_link": "file-G18J8gj433GXK64g20jGY017"
-          }
-        ],
-        "cmd": "sh swiss_army_cmd_line.sh"
-      }
-    },
-    {
-      "id": "stage-G0KbXP0433GXJyYVFfQvqKQQ",
-      "executable": "applet-FyFKBV841zg66G9447B0xKVQ",
-      "folder": "pindel_v1.0.0",
-      "input": {
-        "insert_size": 250,
-        "vcf_gatk_compatible": true,
-        "export_vcf_advanced_options": "-R hg38 -d 25009 --min_size 1 --min_coverage 10 --min_supporting_reads 5",
-        "reference_fasta": {
-          "$dnanexus_link": "file-Fy4gjFj41zgGjKJ85FYYPX4q"
-        },
-        "fasta_index": {
+        "mutect2_fai": {
           "$dnanexus_link": "file-G00jqQj4J7Byv963KkZ40kXv"
         },
-        "mappings_files": [
-          {
-            "$dnanexus_link": {
-              "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
-              "outputField": "mappings_bam"
-            }
+        "bed": {
+          "$dnanexus_link": "file-FybyxV841zgB8v1y3fFbFB0G"
+        },
+        "vcf": {
+          "$dnanexus_link": {
+            "outputField": "variants_vcf",
+            "stage": "stage-G0qpY1Q433GpzBp958KJYfBK"
           }
-        ],
-        "bam_index_files": [
-          {
-            "$dnanexus_link": {
-              "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
-              "outputField": "mappings_bam_bai"
-            }
-          }
-        ]
-      }
-    },
-    {
-      "id": "stage-G0Y8730433Gb8g1g71jQJBZQ",
-      "executable": "app-swiss-army-knife/4.0.1",
-      "folder": "pindel_filtering_v1.0.0",
-      "input": {
-        "in": [
-          {
-            "$dnanexus_link": {
-              "stage": "stage-G0KbXP0433GXJyYVFfQvqKQQ",
-              "outputField": "vcf"
-            }
-          },
-          {
-            "$dnanexus_link": "file-G0bFvXQ433GZJq780QgxZxKf"
-          },
-          {
-            "$dnanexus_link": "file-G0kpq7Q433Gj2XQ89FXYpBzq"
-          }
-        ],
-        "cmd": "sh pindel_filtering_v*.sh"
+        },
+        "mutect2_fasta": {
+          "$dnanexus_link": "file-Fy4gjFj41zgGjKJ85FYYPX4q"
+        }
       }
     },
     {
@@ -153,20 +74,35 @@
       "executable": "applet-G00xzx04J7BZ0684489Gpv8Q",
       "folder": "cgppindel_v1.0.0",
       "input": {
-        "docker_image": {
-          "$dnanexus_link": "file-Fz0KxFj4KB7fxxZ06vy2B2P3"
+        "reference_index": {
+          "$dnanexus_link": "file-G00jqQj4J7Byv963KkZ40kXv"
+        },
+        "tumour": {
+          "$dnanexus_link": {
+            "outputField": "mappings_bam",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
+          }
         },
         "reference": {
           "$dnanexus_link": "file-Fy4gjFj41zgGjKJ85FYYPX4q"
         },
+        "normal": {
+          "$dnanexus_link": "file-Fy9BXxQ40vjGfxP46Jb78Xf1"
+        },
         "simrep": {
           "$dnanexus_link": "file-Fz0Q2GQ41zgB8BK7143y65Q1"
         },
-        "reference_index": {
-          "$dnanexus_link": "file-G00jqQj4J7Byv963KkZ40kXv"
+        "tumour_index": {
+          "$dnanexus_link": {
+            "outputField": "mappings_bam_bai",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
+          }
         },
-        "simrep_index": {
-          "$dnanexus_link": "file-Fz0Q2Kj41zg0Fgk4G70P9P1X"
+        "genes": {
+          "$dnanexus_link": "file-FybyxV841zgB8v1y3fFbFB0G"
+        },
+        "normal_index": {
+          "$dnanexus_link": "file-Fy9BXxQ40vj7qPJq1Kppjx0F"
         },
         "unmatched": {
           "$dnanexus_link": "file-Fz8Q0vj41zg6j03fP1vbvfFp"
@@ -174,53 +110,38 @@
         "filter": {
           "$dnanexus_link": "file-Fz8xvQj41zgGg10ZJzx8Qz53"
         },
-        "normal": {
-          "$dnanexus_link": "file-Fy9BXxQ40vjGfxP46Jb78Xf1"
+        "simrep_index": {
+          "$dnanexus_link": "file-Fz0Q2Kj41zg0Fgk4G70P9P1X"
         },
-        "normal_index": {
-          "$dnanexus_link": "file-Fy9BXxQ40vj7qPJq1Kppjx0F"
-        },
-        "genes": {
-          "$dnanexus_link": "file-FybyxV841zgB8v1y3fFbFB0G"
-        },
-        "tumour": {
-          "$dnanexus_link": {
-            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
-            "outputField": "mappings_bam"
-          }
-        },
-        "tumour_index": {
-          "$dnanexus_link": {
-            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
-            "outputField": "mappings_bam_bai"
-          }
+        "docker_image": {
+          "$dnanexus_link": "file-Fz0KxFj4KB7fxxZ06vy2B2P3"
         }
       }
     },
     {
       "id": "stage-G0Y87ZQ433Gy6y7vBB74p30j",
-      "executable": "app-swiss-army-knife/4.0.1",
+      "executable": "app-swiss-army-knife/4.3.0",
       "folder": "cgppindel_filtering_v1.0.0",
       "input": {
         "cmd": "sh cgppindel_filtering_v*.sh",
         "in": [
           {
             "$dnanexus_link": {
-              "stage": "stage-G02ZFz0433GpQB4j9Gvg0b81",
-              "outputField": "output_vcf"
+              "outputField": "vcf_index",
+              "stage": "stage-G02ZFz0433GpQB4j9Gvg0b81"
             }
           },
           {
             "$dnanexus_link": {
-              "stage": "stage-G02ZFz0433GpQB4j9Gvg0b81",
-              "outputField": "vcf_index"
+              "outputField": "output_vcf",
+              "stage": "stage-G02ZFz0433GpQB4j9Gvg0b81"
             }
           },
           {
-            "$dnanexus_link": "file-G0bFvXQ433GZJq780QgxZxKf"
+            "$dnanexus_link": "file-G0Y97F0433GqF68j5fvz9fb6"
           },
           {
-            "$dnanexus_link": "file-G0Y97F0433GqF68j5fvz9fb6"
+            "$dnanexus_link": "file-G0bFvXQ433GZJq780QgxZxKf"
           }
         ]
       }
@@ -233,16 +154,16 @@
         "vcf_file": {
           "$dnanexus_link": "file-G07zJxj41zgF593x6j7bqZ7X"
         },
-        "input_bam": {
-          "$dnanexus_link": {
-            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
-            "outputField": "mappings_bam"
-          }
-        },
         "input_bam_index": {
           "$dnanexus_link": {
-            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
-            "outputField": "mappings_bam_bai"
+            "outputField": "mappings_bam_bai",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
+          }
+        },
+        "input_bam": {
+          "$dnanexus_link": {
+            "outputField": "mappings_bam",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
         }
       }
@@ -252,18 +173,18 @@
       "executable": "applet-Fp69k884qBzVfbvP812F92gG",
       "folder": "eggd_picardqc_v1.0.0",
       "input": {
-        "run_CollectTargetedPcrMetrics": true,
-        "fasta_index": {
-          "$dnanexus_link": "file-Fy4j2G04qB6zQK885B5Q8Pqp"
+        "sorted_bam": {
+          "$dnanexus_link": {
+            "outputField": "mappings_bam",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
+          }
         },
+        "run_CollectTargetedPcrMetrics": true,
         "bedfile": {
           "$dnanexus_link": "file-Fzp57Jj41zg5KbV72PVVGkkb"
         },
-        "sorted_bam": {
-          "$dnanexus_link": {
-            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
-            "outputField": "mappings_bam"
-          }
+        "fasta_index": {
+          "$dnanexus_link": "file-Fy4j2G04qB6zQK885B5Q8Pqp"
         }
       }
     },
@@ -272,16 +193,16 @@
       "executable": "applet-Fk5z0V84yBGZ5P7q3gFgFB64",
       "folder": "samtools_flagstat_v1.0.0",
       "input": {
-        "input_bam": {
-          "$dnanexus_link": {
-            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
-            "outputField": "mappings_bam"
-          }
-        },
         "input_bam_index": {
           "$dnanexus_link": {
-            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
-            "outputField": "mappings_bam_bai"
+            "outputField": "mappings_bam_bai",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
+          }
+        },
+        "input_bam": {
+          "$dnanexus_link": {
+            "outputField": "mappings_bam",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
         }
       }
@@ -291,50 +212,47 @@
       "executable": "applet-Fxq07gQ433Gyz14j5ZZ1fzk1",
       "folder": "eggd_mosdepth_v1.0.1",
       "input": {
-        "bed": {
-          "$dnanexus_link": "file-FybyxV841zgB8v1y3fFbFB0G"
+        "index": {
+          "$dnanexus_link": {
+            "outputField": "mappings_bam_bai",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
+          }
         },
         "bam": {
           "$dnanexus_link": {
-            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
-            "outputField": "mappings_bam"
-          }
-        },
-        "index": {
-          "$dnanexus_link": {
-            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV",
-            "outputField": "mappings_bam_bai"
+            "outputField": "mappings_bam",
+            "stage": "stage-G0qpXy0433Gv75XbPJ3xj8jV"
           }
         }
       }
     },
     {
       "id": "stage-G02ZG6Q433GV76v29b6Gggjp",
-      "executable": "applet-FykqQzj433GbQXFqJY70jFvJ",
-      "folder": "athena_v1.0.3",
+      "executable": "applet-G1Jb6v0433Gv5qj33B30bqjp",
+      "folder": "athena_v1.1.2",
       "input": {
-        "thresholds": "100, 250, 500, 1000, 1500",
-        "cutoff_threshold": 250,
-        "summary": true,
-        "panel_bed": {
-          "$dnanexus_link": "file-FybxKB041zg3PgQ467BfFYKq"
-        },
-        "exons_nirvana": {
-          "$dnanexus_link": "file-FybxJ4Q41zgP75z7B2F1jbgg"
-        },
         "snps": [
           {
             "$dnanexus_link": "file-FyZfyqQ41zg5FjK2GykYfKq8"
           }
         ],
+        "thresholds": "100, 250, 500, 1000, 1500",
+        "exons_nirvana": {
+          "$dnanexus_link": "file-FybxJ4Q41zgP75z7B2F1jbgg"
+        },
+        "summary": true,
         "mosdepth_files": [
           {
             "$dnanexus_link": {
-              "stage": "stage-Fy4j4K041zgF5Z8y0x9KjV55",
-              "outputField": "mosdepth_output"
+              "outputField": "mosdepth_output",
+              "stage": "stage-Fy4j4K041zgF5Z8y0x9KjV55"
             }
           }
-        ]
+        ],
+        "cutoff_threshold": 250,
+        "panel_bed": {
+          "$dnanexus_link": "file-G23Jqbj4q5J0jkVb0Xj97Vgy"
+        }
       }
     }
   ]


### PR DESCRIPTION
### Uranus main workflow v1.3.0 includes the following changes: ###
1. Includes the eggd_vcf_handler_for_uranus app that processes sentieon tnhaplotyper2 vcfs (see GEN.BI.321). This app does the following:
* Annotates and filters the sentieon mutect2 VCF
* Produces a tsv variant list that provides clinical scientists with a complete list of variants with some annotation and preformatted text for Epic
* Produces a VCF that can be used as input for BSVI, which is incompatible with mutect2's (correct) representation of multiallelic variants in VCF
2. Removed the bed file from mosdepth in order to create unrestricted (all exons) coverage reports further down by athena
3. Updated athena to latest version (v1.1.2) and replaced bed file from restricted version to unrestricted (all exons) version in order to create unrestricted (all exons) coverage reports_
4. Removed the pindel app as it has been fully replaced by cgppindel
5. Update Swiss Army Knife app to v4.3.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_uranus_main_workflow/7)
<!-- Reviewable:end -->
