### PR TITLE
Release v1.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # eggd_uranus_workflow (DNAnexus Platform Workflow)
 DNAnexus Uranus workflow to support the Haem-Onc myeloid project
 
-This workflow is a modified version of v1.6.0 (Novaseq) that is compatible with data produced by the Novaseq Instrument
+This workflow is a modified version of v1.7.0 (Novaseq) that is compatible with data produced by the Novaseq Instrument
 
 -------
 
-## Current Version: 1.6.0
+## Current Version: 1.7.0
 ![Image of workflow](uranus_main_workflow_v1.6.0.png)
 
 ## What apps are used in this workflow?
@@ -15,7 +15,7 @@ This workflow is a modified version of v1.6.0 (Novaseq) that is compatible with 
 |multi_fastqc       |1.1.0|
 |sentieon_bwa_mem   |2.1.0|
 |sentieon_bam_to_vcf|2.1.0|_
-|eggd_vcf_handler_for_uranus|2.1.0|
+|eggd_vcf_handler_for_uranus|2.2.0|
 |cgppindel          |1.0.0|
 |swiss_army_knife	|4.3.0|
 |verifybamid        |2.1.0|

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -41,8 +41,8 @@
     },
     {
       "id": "stage-G21GYKj4q5J37F0B5ky018QG",
-      "executable": "app-eggd_vcf_handler_for_uranus/2.1.0",
-      "folder": "eggd_vcf_handler_for_uranus_v2.1.0",
+      "executable": "app-eggd_vcf_handler_for_uranus/2.2.0",
+      "folder": "eggd_vcf_handler_for_uranus_v2.2.0",
       "input": {
         "bed": {
           "$dnanexus_link": "file-G41x2xQ433GYX43Z81vpG6P4"


### PR DESCRIPTION
- updates eggd_athena applet in workflow from v1.1.2 -> v1.2.2
  - includes improved usability of reports, reduction in file size and faster run time for app
- updates eggd_vcf_handler_for_uranus from v2.1.0 -> v2.2.0
  - updated MAF file with 205 NovaSeq samples
  - updated October 2021 ClinVar VCF included in default VEP tarball
  - improvements to annotation and filtering with VEP 
  - release notes: https://github.com/eastgenomics/eggd_vcf_handler_for_uranus/releases/tag/v2.2.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_uranus_main_workflow/14)
<!-- Reviewable:end -->
