### PR TITLE
Updated apps with no resource file IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ DNAnexus Uranus workflow to support the Haem-Onc myeloid service
 |---	|---	|
 |sentieon-bwa   |3.2.0|
 |sentieon-tnbam|3.2.0|
-|cgppindel          |1.1.0|
+|cgppindel          |1.2.0|
 |verifybamid        |2.2.1|
 |picardqc           |1.1.0|
 |samtools_flagstat  |1.1.0|
 |mosdepth           |1.1.0|
 |athena             |1.4.0|
 |somalier_extract   |1.1.0|
-|sompy              |1.0.3|
-|eggd_vcf_handler_for_uranus|2.7.0|
+|sompy              |1.0.4|
+|eggd_vcf_handler_for_uranus|2.8.0|
 |eggd_apheleia|1.0.1|

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -1,6 +1,6 @@
 {
-  "name": "uranus_main_workflow_GRCh38_v2.0.0",
-  "title": "uranus_main_workflow_GRCh38_v2.0.0",
+  "name": "uranus_main_workflow_GRCh38_v2.1.0",
+  "title": "uranus_main_workflow_GRCh38_v2.1.0",
   "summary": "Main workflow for Uranus pipeline",
   "stages": [
     {
@@ -23,8 +23,8 @@
     },
     {
       "id": "stage-eggd_vcf_handler_for_uranus",
-      "executable": "app-eggd_vcf_handler_for_uranus/2.7.0",
-      "folder": "eggd_vcf_handler_for_uranus_v2.7.0",
+      "executable": "app-eggd_vcf_handler_for_uranus/2.8.0",
+      "folder": "eggd_vcf_handler_for_uranus_v2.8.0",
       "input": {
         "mutect2_vcf": {
           "$dnanexus_link": {
@@ -48,7 +48,7 @@
     },
     {
       "id": "stage-cgppindel",
-      "executable": "app-eggd_cgppindel/1.1.0",
+      "executable": "app-eggd_cgppindel/1.2.0",
       "folder": "eggd_cgppindel",
       "input": {
         "tumour": {
@@ -159,8 +159,8 @@
     },
     {
       "id": "stage-sompy",
-      "executable": "app-eggd_sompy/1.0.3",
-      "folder": "eggd_sompy_v1.0.3",
+      "executable": "app-eggd_sompy/1.0.4",
+      "folder": "eggd_sompy_v1.0.4",
       "input": {
         "query_vcf": {
           "$dnanexus_link": {


### PR DESCRIPTION
Updated app versions to not include resource file IDs as default:
 -eggd_cgppindel to v1.2.0
-eggd_sompy to v1.0.4
-eggd_vcf_handler_for_uranus to v2.8.0
Updated README

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_uranus_main_workflow/33)
<!-- Reviewable:end -->
