### PR TITLE
Update BWA and TNbam to v5.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ DNAnexus Uranus workflow to support the Haem-Onc myeloid service
 
 |  App 	| Version  	|
 |---	|---	|
-|sentieon-bwa   |4.2.2|
-|sentieon-tnbam|5.0.1|
+|sentieon-bwa   |5.1.0|
+|sentieon-tnbam|5.1.0|
 |cgppindel          |1.2.0|
 |verifybamid        |2.2.1|
 |picardqc           |1.1.0|

--- a/dxworkflow.json
+++ b/dxworkflow.json
@@ -5,12 +5,12 @@
   "stages": [
     {
       "id": "stage-sentieon_bwa",
-      "executable": "app-sentieon-bwa/4.2.2",
+      "executable": "app-sentieon-bwa/5.1.0",
       "folder": "sentieon_bam"
     },
     {
       "id": "stage-sentieon_tnbam",
-      "executable": "app-sentieon-tnbam/5.0.1",
+      "executable": "app-sentieon-tnbam/5.1.0",
       "folder": "sentieon_vcfs",
       "input": {
         "mappings_bam": {


### PR DESCRIPTION
Updated workflow to use Sentieon BWA and TNbam v5.1.0 in line with the 2025 licence patch requirements.
Changes:
- sentieon-bwa: 4.2.2 → 5.1.0
- sentieon-tnbam: 5.0.1 → 5.1.0

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_uranus_main_workflow/40)
<!-- Reviewable:end -->
